### PR TITLE
update ICPC APAC

### DIFF
--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -14,6 +14,24 @@ export type Achievemet = {
 
 export const achievements: Achievemet[] = [
     {
+        id: 'icpc-2026-taiwan',
+        title: '2026 ICPC Asia Pacific Championship 5位 World Finals 進出決定',
+        date: '2026-03-06,09',
+        summary: 'チーム「bogosort」として出場し，ライブラリ整備や幾何・パズル系問題を担当．',
+        details: [
+            'チームメンバーと過去問題の本番演習をかなり強化して行った．',
+            '持ち込み用ライブラリの整備を担当．高度データ構造の実装を行った．',
+            '2026年11月に開催予定のWorld Finalsへの進出が決定した．',
+        ],
+        tags: ['ICPC', '競技プログラミング'],
+        links: [
+            {
+                label: 'The 2026 ICPC Asia Pacific Championship',
+                url: 'https://apac.icpc.global/championship/2026/competition/'
+            }
+        ]
+    },
+    {
         id: 'icpc-2025-yokohama',
         title: 'ICPC 2025 Yokohama Regional Contest 5位 Asia Pacific Championship 進出決定',
         org: 'ICPC 2025 横浜大会 実行委員会',

--- a/src/data/activitiesIndex.ts
+++ b/src/data/activitiesIndex.ts
@@ -11,7 +11,7 @@ export const activitiesIndex: ActivityMeta[] = [
     slug: 'competitive',
     title: '競技プログラミング',
     summary:
-      'AtCoder・Codeforces．ICPC 国内予選 2025:12位（bogosort, アジア横浜進出）/ 2024:16位．作問(KCPC, Library Checker)．幾何・データ構造のライブラリ整備．',
+      'AtCoder・Codeforces．ICPC Asia Pacific Championship 2026 5位 WF進出(team: bogosort)．作問(KCPC, Library Checker)．ライブラリ整備．',
     icon: '🏁',
     updated: '2025-07',
   },

--- a/src/pages/activities/Competitive.tsx
+++ b/src/pages/activities/Competitive.tsx
@@ -73,6 +73,20 @@ export default function Competitive() {
           <ol className="relative not-prose list-none border-l border-slate-300 dark:border-slate-700 pl-6 space-y-6 text-[0.95rem]">
             <li className="relative">
               <span className="absolute -left-3 top-2 h-2 w-2 rounded-full bg-sky-600" />
+              <div className="font-semibold">2026 ICPC Asia Pacific Championship — bogosort</div>
+              <div>
+                結果：5位．World Finals 進出（
+                <a className="underline" href="https://icpc.global/regionals/finder/APSEPC-2026/standings" target="_blank" rel="noreferrer">
+                  順位表
+                </a>
+                ）
+              </div>
+              <div className="text-slate-600 dark:text-slate-300">
+                役割：ライブラリ整備，テスト作成，デバッグ支援，幾何・パズル系問題担当
+              </div>
+            </li>
+            <li className="relative">
+              <span className="absolute -left-3 top-2 h-2 w-2 rounded-full bg-sky-600" />
               <div className="font-semibold">2025 Asia Yokohama Regional Contest — bogosort</div>
               <div>
                 結果：5位．Asia Pacific Championship 進出（


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates static portfolio content (achievement data and page copy) with no logic, API, or data-handling changes.
> 
> **Overview**
> Adds a new `icpc-2026-taiwan` achievement entry (APAC 2026 5th place, World Finals qualification) including details, tags, and an external link.
> 
> Updates the competitive programming index blurb and the `Competitive` page ICPC timeline to include the APAC 2026 result and standings link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b688a97d21d9040e47f1ab96edb1f3fdd753bd32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->